### PR TITLE
Fixed typo in the installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The native install method is preferred and more performant, so it's best if you'
 
 ```
 git clone git@github.com:northstack/northstack-client.git
-cd northstack
+cd northstack-client
 ./bin/install.sh
 ```
 


### PR DESCRIPTION
`cd northstack` -> `cd northstack-client`