### PR TITLE
Use $BIN_DIR instead of $CDIR

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -eu
 
-CDIR="$( cd "$( dirname "${BASH_SOURCE[0]}")"  && pwd)"
-BASE="$( dirname "$CDIR")"
+BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")"  && pwd)"
+BASE="$( dirname "$BIN_DIR")"
 
-. "$CDIR"/lib.sh
-. "$CDIR"/lib-install.sh
+. "$BIN_DIR"/lib.sh
+. "$BIN_DIR"/lib-install.sh
 
 showBanner() {
     local NS_RED='\033[0;31m'


### PR DESCRIPTION
This fixes the case where you run the installer script from outside of the repo base:
```
michaelm@lobster-x ~/git $ ./northstack/bin/install.sh -h
/home/michaelm/git/northstack/bin/lib-install.sh: line 4: ./bin/lib.sh: No such file or directory
```