### PR TITLE
Fix show_spinner_cmd in installer

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -58,7 +58,8 @@ while getopts "vdnha:p:m:" opt; do
             export NON_INTERACTIVE=1
             ;;
         m)
-            export INSTALL_METHOD=$(strToLower "$OPTARG")
+            method=$(strToLower "$OPTARG")
+            export INSTALL_METHOD=$method
             ;;
         d)
             export INSTALL_DEV_MODE=1

--- a/bin/lib-install.sh
+++ b/bin/lib-install.sh
@@ -80,11 +80,10 @@ getVersion() {
             ;;
     esac
 
-    local version
-    version=$("${cmd[@]}" 2>&1)
+    local version; version=$("${cmd[@]}" 2>&1)
     local status=$?
 
-    local strCmd=$(quoteCmd "${cmd[@]}")
+    local strCmd; strCmd=$(quoteCmd "${cmd[@]}")
     if [[ $status -ne 0 ]]; then
         log error "Failed to check the installed version of $name" \
             "Command \`$strCmd\` returned $status" \
@@ -282,11 +281,10 @@ updateBashProfile() {
         return 1
     fi
 
-    local checksumPre=$(md5sum "$bashFile" | awk '{print $1}')
-    local new=$(mktemp)
+    local checksumPre; checksumPre=$(md5sum "$bashFile" | awk '{print $1}')
+    local new; new=$(mktemp)
 
     local startLine
-
     startLine=$(sed -n -e '/^# NorthStack START$/=' < "$bashFile")
 
     if [[ -n $startLine ]]; then
@@ -302,14 +300,14 @@ updateBashProfile() {
     endLine=$(sed -n -e '/^# NorthStack END$/=' < "$bashFile")
 
     if [[ -n $endLine ]]; then
-        local total=$(wc -l "$bashFile" | awk '{print $1}')
-        local lastN=$((total - endLine + 1))
+        local total; total=$(wc -l "$bashFile" | awk '{print $1}')
+        local lastN; lastN=$((total - endLine + 1))
         tail -n "$lastN" "$bashFile" >> "$new"
     else
         echo '# NorthStack END' >> "$new"
     fi
 
-    local checksumPost=$(md5sum "$bashFile" | awk '{print $1}')
+    local checksumPost; checksumPost=$(md5sum "$bashFile" | awk '{print $1}')
 
     if [[ $checksumPre != "$checksumPost" ]]; then
         log error "RC file ($bashFile) changed while we were updating it"
@@ -346,7 +344,7 @@ checkPathPermissions() {
     for item in "${toCheck[@]}"; do
         local name=${item%%:*}
         local path=${item#*:}
-        local parent=$(parentDir "$path")
+        local parent; parent=$(parentDir "$path")
         if [[ -e $path && ! -w $path ]]; then
             setError "${name}_path" "$name path ($path) exists but is not writable."
             setError "${name}_path" "$(readableStat "$path")"
@@ -366,7 +364,7 @@ doNativeInstall() {
 
     shopt -s dotglob nullglob
     for p in "$context"/*; do
-        local name=$(basename "$p")
+        local name; name=$(basename "$p")
         if [[ "$p" =~ (\.(git|buildkite|github|tmp)$) ]]; then
             continue
         fi
@@ -416,7 +414,7 @@ doDockerInstall() {
     [[ $isDev == 1 ]] && installComposerDeps "$context"
     buildDockerImage "$context"
 
-    local wrapperFile=$(mktemp)
+    local wrapperFile; wrapperFile=$(mktemp)
 
     # shellcheck disable=SC2064
     #trap "rm -f '$wrapperFile'" EXIT

--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -48,7 +48,7 @@ log() {
             ;;
     esac
 
-    local ts=$(date '+%Y-%m-%d %H:%M:%S')
+    local ts; ts=$(date '+%Y-%m-%d %H:%M:%S')
     local template="[$ts] [$level] %s\n"
     if [[ -t 2 ]]; then
         template="[${white}${ts}${end}] [${level_color}${level}${end}] %s\n"
@@ -78,7 +78,7 @@ debug() {
 }
 
 getInstallPrefix() {
-    local binDir="$(getCwd)"
+    local binDir; binDir="$(getCwd)"
     printf "$(dirname "$binDir")"
 }
 
@@ -125,7 +125,7 @@ copyFile() {
         return 1
     fi
 
-    local parent=$(dirname "$dest")
+    local parent; parent=$(dirname "$dest")
     mkdirP "$parent" || return 1
 
     debugCmd cp -va "$src" "$dest"
@@ -146,7 +146,7 @@ copyTree() {
         log warn "Destination directory ($dest) already exists--removing"
         rmDir "$dest"
     elif [[ -e $dest ]]; then
-        local filetype=$(stat -c '%F' "$dest")
+        local filetype; filetype=$(stat -c '%F' "$dest")
         log error "Destination exists but is not a directory: $filetype"
         return 1
     fi
@@ -238,7 +238,7 @@ lnS() {
         rmFile "$link"
     fi
 
-    local parent=$(dirname "$link")
+    local parent; parent=$(dirname "$link")
 
     mkdirP "$parent"
 
@@ -283,15 +283,14 @@ rmDir() {
 }
 
 quoteCmd() {
-    local cmd=$(printf '%q ' "$@")
+    local cmd; cmd=$(printf '%q ' "$@")
     printf "${cmd% }"
 }
 
 debugCmd() {
-    local cmd=$(quoteCmd "$@")
-    debug "Running:" "$cmd"
+    debug "Running:" "$(quoteCmd "$@")"
 
-    local tmp=$(mktemp -d)
+    local tmp; tmp=$(mktemp -d)
 
     local flags="$-"
     set +e
@@ -347,7 +346,7 @@ dockerSocket() {
 }
 
 checkPaths() {
-    local prefix=$(getInstallPrefix)
+    local prefix; prefix=$(getInstallPrefix)
     local failed=0
 
     if [[ $DEV_MODE == 1 ]] && [[ ! -d $DEV_SOURCE ]]; then

--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -416,56 +416,6 @@ installComposerDeps() {
     debug "Completed all of the composer install stuff. Onward!"
 }
 
-# Display text in a chosen color
-# @param $color text color
-# @param $message
-# param bool $newline return at the end of the line(defaults to true)
-#param $backgroundColor optional, defaults to transparent
-# shellcheck disable=SC2034
-colorText() {
-    local color=$1
-    local prefix=$'\e['
-    local end=$'\e[0m'
-    local background=${4:-""}
-
-    local textPrefix="38;5;"
-
-    local red="196"
-    local orange="208"
-    local yellow="226"
-    local green="82"
-    local cyan="45"
-    local blue="27"
-    local purple="129"
-    local magenta="199"
-    local black="0"
-    local white="255"
-    local grey="242"
-
-    color=${!color:=}
-
-    if [[ -z "$background" ]]; then
-        color=${prefix}${textPrefix}${color}m
-    else
-        local bgPrefix="48;5;"
-        background=${!background:=}
-        color=${prefix}${textPrefix}${color}m${prefix}${bgPrefix}${background}m
-    fi
-
-    local defaultMSG=""
-    local defaultNewLine=true
-
-    local message=${2:-$defaultMSG}    # Defaults to default message.
-    local newLine=${3:-$defaultNewLine}
-
-    echo -en "${color}${message}${end}"
-    if [ "$newLine" = true ]; then
-        echo
-    fi
-
-    return
-}
-
 show_spinner_cmd() {
     if shellIsInteractive; then
         # we don't want anything to try to read from stdin in this context

--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -84,7 +84,6 @@ getInstallPrefix() {
 
 shellIsInteractive() {
     [[ -t 0 ]] && [[ -z ${NON_INTERACTIVE:-} ]]
-    #[[ -t 0 || -p /dev/stdin ]]
 }
 
 ask() {
@@ -158,7 +157,6 @@ copyTree() {
     dest=${dest%/}
 
     debugCmd cp -v -f -a "$src" "$dest"
-    #rsync -HavzuP --delete "$src" "$dest"
 }
 
 parentDir() {

--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -16,10 +16,10 @@ log() {
 
     local red=$'\e[1;91m'
     local green=$'\e[1;32m'
-    local yellow=$'\e[1;33m'
+    #local yellow=$'\e[1;33m'
     local blue=$'\e[1;34m'
     local magenta=$'\e[1;35m'
-    local cyan=$'\e[1;36m'
+    #local cyan=$'\e[1;36m'
     local white=$'\e[1;37m'
     local end=$'\e[0m'
 

--- a/tests/bash/test-lib-show_spinner_cmd.bats
+++ b/tests/bash/test-lib-show_spinner_cmd.bats
@@ -29,3 +29,11 @@ load helpers
     run show_spinner_cmd cat
     assert equal 0 $status
 }
+
+@test "show_spinner_cmd doesn't hide the output of a command" {
+    t=$(mktemp)
+    echo $RANDOM > "$t"
+    run show_spinner_cmd cat "$t"
+    assert stringContains "$(< "$t")" "$output"
+    assert equal 0 $status
+}

--- a/tests/bash/test-lib-show_spinner_cmd.bats
+++ b/tests/bash/test-lib-show_spinner_cmd.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+source "$BIN_DIR/lib.sh"
+
+load helpers
+
+@test "show_spinner_cmd returns the same exit code as the command it runs" {
+    shellIsInteractive() { return 0; }
+    export -f shellIsInteractive
+
+    ret() { return $1; }
+    export -f ret
+
+    run show_spinner_cmd ret 0
+    assert equal 0 $status
+
+    run show_spinner_cmd ret 127
+    assert equal 127 $status
+
+    run show_spinner_cmd debugCmd ret 1
+    assert equal 1 $status
+}
+
+
+@test "show_spinner_cmd doesn't break with commands that try to read from stdin" {
+    shellIsInteractive() { return 0; }
+    export -f shellIsInteractive
+
+    run show_spinner_cmd cat
+    assert equal 0 $status
+}

--- a/tests/build-bats.sh
+++ b/tests/build-bats.sh
@@ -4,7 +4,7 @@ set -eu
 
 CDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-stamp=$(stat -c %Y "$CDIR"/docker/Dockerfile)
+stamp=$(stat -c %Y "$CDIR"/docker)
 bats_version=$(awk -F= '/^ARG BATS_VERSION/ {print $2}' "$CDIR"/docker/Dockerfile)
 
 repo=northstack/bats

--- a/tests/docker/.shellcheckrc
+++ b/tests/docker/.shellcheckrc
@@ -7,10 +7,6 @@ shell=bash
 #   - using printf with a variable in the template is harmless enough
 #   - https://github.com/koalaman/shellcheck/wiki/SC2059
 #
-# - SC2155
-#   - assign/execute in same expression ie 'local stamp=$(date)'
-#   - https://github.com/koalaman/shellcheck/wiki/SC2155
-#
 # - SC1090 + SC1091
 #   - don't complain when shellcheck can't find a sourced file
 #   - https://github.com/koalaman/shellcheck/wiki/SC1090
@@ -20,4 +16,4 @@ shell=bash
 #   - checking the last command's return code with `$?`
 #   - https://github.com/koalaman/shellcheck/wiki/SC2181
 
-disable=SC2059,SC2155,SC1090,SC1091,SC2181
+disable=SC2059,SC1090,SC1091,SC2181


### PR DESCRIPTION
`show_spinner_cmd` was returning `0` regardless of what the command itself returned, which is bad since we rely on `set -e` to bail out whenever a command fails.

Also, stop ignoring shellcheck lint error SC2155. Makes for uglier code, but less painful debug.

Instead of:
```
# these raise no error
local foo=$(exit 1)
export bar=$(exit 1)
```
Prefer:
```
local foo
foo=$(exit 1)
```
or
``` 
local foo; foo=$(exit 1)
```