### PR TITLE
UserInput helpers

### DIFF
--- a/src/AppTypes/BaseType.php
+++ b/src/AppTypes/BaseType.php
@@ -36,67 +36,50 @@ abstract class BaseType
         $this->config = $userConfig;
     }
 
-    public static function getArgs()
+    abstract public static function getArgs();
+
+    public static function getInputOptions()
     {
-        return static::$args;
+        foreach (static::getArgs() as $arg)
+        {
+            if ($arg->getName() === 'frameworkVersion')
+            {
+                continue;
+            }
+            yield $arg->asInputOption();
+        }
     }
 
     public function promptForArgs()
     {
         $options = $this->input->getOptions();
+        foreach (static::getArgs() as $arg) {
+            $name = $arg->getName();
 
-        foreach (static::$args as $name => $arg) {
+            $input = $this->input->getOption($name);
             // skip the question if the user already set the value in an option
-            if (null !== $options[$name]) {
-                $this->config[$name] = $options[$name];
+            if (null !== $input && $input !== $arg->getDefault())
+            {
+                $this->config[$name] = $input;
                 continue;
             }
 
+            /*
             if (isset($arg['depends'])) {
                 $depends = $arg['depends'];
                 if (!$this->config[$depends]) {
                     continue;
                 }
             }
+            */
 
-            $prompt = $arg['prompt'];
-            $default = $this->defaultValue($arg['default']);
-            if (isset($default)) {
-                $_default = ($default === false) ? 'false' : (string)$default;
-                $prompt .= " (Default: {$_default})";
-            }
+            $arg->setDefault(
+                $this->defaultValue(
+                    $arg->getDefault()
+                )
+            );
 
-            $prompt .= " ";
-
-            $question = null;
-            if (isset($arg['type']) && $arg['type'] === 'bool') {
-                $question = new ConfirmationQuestion(
-                    $prompt,
-                    $default
-                );
-            } elseif (isset($arg['choices'])) {
-                $question = new ChoiceQuestion(
-                    $prompt,
-                    $arg['choices'],
-                    $default
-                );
-            } else {
-                $question = new Question($prompt, $default);
-            }
-
-            if (array_key_exists('passwordInput', $arg) && ($arg['passwordInput'] === true)) {
-                $question->setHidden(true);
-            }
-
-            $answer = $this->askQuestion($question);
-
-            if (
-                array_key_exists('isRandom', $arg) &&
-                ($arg['isRandom'] === true) &&
-                ($answer === $arg['default'])
-            ) {
-                $answer = bin2hex(random_bytes($arg['randomLen']));
-            }
+            $answer = $this->askQuestion($arg->asQuestion());
 
             $this->config[$name] = $answer;
         }

--- a/src/AppTypes/GatsbyType.php
+++ b/src/AppTypes/GatsbyType.php
@@ -2,12 +2,14 @@
 
 namespace NorthStack\NorthStackClient\AppTypes;
 
+use NorthStack\NorthStackClient\UserInput\BasicInput;
+
 class GatsbyType extends BaseType
 {
-    protected static $args = [
-        'frameworkVersion' => [
-            'prompt' => 'Gatsby version: ',
-            'default' => '2.5.0'
-        ]
-    ];
+    public static function getArgs()
+    {
+        return [
+            new BasicInput('frameworkVersion', 'Gatsby version', '2.5.0')
+        ];
+    }
 }

--- a/src/AppTypes/JekyllType.php
+++ b/src/AppTypes/JekyllType.php
@@ -2,12 +2,14 @@
 
 namespace NorthStack\NorthStackClient\AppTypes;
 
+use NorthStack\NorthStackClient\UserInput\BasicInput;
+
 class JekyllType extends BaseType
 {
-    protected static $args = [
-        'frameworkVersion' => [
-            'prompt' => 'Jekyll version: ',
-            'default' => '3'
-        ]
-    ];
+    public static function getArgs()
+    {
+        return [
+            new BasicInput('frameworkVersion', 'Jekyll version', '3')
+        ];
+    }
 }

--- a/src/AppTypes/StaticType.php
+++ b/src/AppTypes/StaticType.php
@@ -4,4 +4,8 @@ namespace NorthStack\NorthStackClient\AppTypes;
 
 class StaticType extends BaseType
 {
+    public static function getArgs()
+    {
+        return [];
+    }
 }

--- a/src/AppTypes/TypeCollection.php
+++ b/src/AppTypes/TypeCollection.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace NorthStack\NorthStackClient\AppTypes;
+
+class TypeCollection
+{
+    protected static $types = [
+        'wordpress' => WordPressType::class,
+        'jekyll'    => JekyllType::class,
+        'gatsby'    => GatsbyType::class,
+        'static'    => StaticType::class,
+    ];
+
+    public static function getTypes()
+    {
+        foreach (self::$types as $name => $type)
+        {
+            yield $type;
+        }
+    }
+
+    public static function getTypeByName($name)
+    {
+        $key = strToLower($name);
+        return self::$types[$key];
+    }
+}

--- a/src/AppTypes/WordPressType.php
+++ b/src/AppTypes/WordPressType.php
@@ -2,46 +2,14 @@
 
 namespace NorthStack\NorthStackClient\AppTypes;
 
+use NorthStack\NorthStackClient\UserInput\BasicInput;
+use NorthStack\NorthStackClient\UserInput\ChoiceInput;
+use NorthStack\NorthStackClient\UserInput\PasswordInput;
+use NorthStack\NorthStackClient\UserInput\BoolInput;
+
 
 class WordPressType extends BaseType
 {
-    protected static $args = [
-        'wpTitle' => [
-            'prompt' => 'Enter the title of the site:',
-            'default' => '$appName',
-        ],
-        'wpAdminUser' => [
-            'prompt' => 'Enter the WP admin username:',
-            'default' => '$accountUsername',
-        ],
-        'wpAdminPass' => [
-            'prompt' => 'Enter the WP admin password:',
-            'default' => 'randomly generated',
-            'isRandom' => true,
-            'randomLen' => 16,
-            'passwordInput' => true
-        ],
-        'wpAdminEmail' => [
-            'prompt' => 'Enter the WP admin email address:',
-            'default' => '$accountEmail',
-        ],
-        'wpIsMultisite' => [
-            'prompt' => 'Is this a multi-site WP app?',
-            'type' => 'bool',
-            'default' => false
-        ],
-        'wpMultisiteSubdomains' => [
-            'prompt' => 'Multi-site mode: ',
-            'choices' => ['subdomain', 'subfolder'],
-            'depends' => 'wpIsMultisite',
-            'default' => 'subdomain'
-        ],
-        'frameworkVersion' => [
-            'prompt' => 'WordPress version: ',
-            'default' => '5.1'
-        ]
-    ];
-
     public function setArgsFromExistingApp($sapps)
     {
         $this->sapps = $sapps;
@@ -69,6 +37,48 @@ class WordPressType extends BaseType
         }
 
         return $config;
+    }
+
+    public static function getArgs()
+    {
+        return [
+            new BasicInput(
+                'wpTitle',
+                'The title for this WordPress app',
+                '$appName'
+            ),
+            new BasicInput(
+                'wpAdminUser',
+                'The WordPress admin username',
+                '$accountUsername'
+            ),
+            new PasswordInput(
+                'wpAdminPass',
+                'The WordPress admin password',
+                16
+            ),
+            new BasicInput(
+                'wpAdminEmail',
+                'The WordPress admin email address',
+                '$accountEmail'
+            ),
+            new BoolInput(
+                'wpIsMultisite',
+                'Is this a multi-site WordPress app?',
+                false
+            ),
+            (new ChoiceInput(
+                'wpMultisiteSubdomains',
+                'The WordPress multi-site mode',
+                'subdomain'
+            ))->setChoices(['subdomain', 'subfolder']),
+            new BasicInput(
+                'frameworkVersion',
+                'The WordPress version',
+                '5.1'
+            )
+        ];
+
     }
 
 }

--- a/src/Command/Sapp/CreateCommand.php
+++ b/src/Command/Sapp/CreateCommand.php
@@ -16,6 +16,7 @@ use NorthStack\NorthStackClient\OrgAccountHelper;
 
 use NorthStack\NorthStackClient\AppTypes\StaticType;
 use NorthStack\NorthStackClient\AppTypes\WordPressType;
+use NorthStack\NorthStackClient\AppTypes\TypeCollection;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -74,18 +75,8 @@ class CreateCommand extends Command
             ->addOption('appSlug', null, InputOption::VALUE_REQUIRED, 'Name to use for the app\'s local directory and local reference')
         ;
 
-        foreach (array_merge(BaseType::getArgs(), StaticType::getArgs(), JekyllType::getArgs(), WordPressType::getArgs(), GatsbyType::getArgs()) as $optKey => $optArgs) {
-            if ('frameworkVersion' === $optKey) {
-                continue;
-            }
-
-            $this->addOption(
-                $optKey,
-                null,
-                InputOption::VALUE_OPTIONAL,
-                $optArgs['prompt'],
-                null
-            );
+        foreach (TypeCollection::getTypes() as $appType) {
+            $this->getDefinition()->addOptions($appType::getInputOptions());
         }
 
         $this->addOauthOptions();

--- a/src/UserInput/AbstractUserInput.php
+++ b/src/UserInput/AbstractUserInput.php
@@ -1,0 +1,75 @@
+<?php
+
+
+namespace NorthStack\NorthStackClient\UserInput;
+
+abstract class AbstractUserInput
+{
+    protected $name;
+    private $value;
+    protected $description;
+    protected $validators = [];
+    protected $default = null;
+
+    abstract public function asInputOption();
+    abstract public function asQuestion();
+
+    public function __construct($name, $description, $default = null)
+    {
+        $this->name = $name;
+        $this->description = $description;
+        $this->default = $default;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    public function getValue($value)
+    {
+        return $this->value;
+    }
+
+    public function setValue($value)
+    {
+        $this->value = $this->validate($value);
+    }
+
+    private function validate($value)
+    {
+        foreach ($this->validators as $validator)
+        {
+            $value = $validator($value);
+        }
+        return $value;
+    }
+
+    public function setDefault($value)
+    {
+        $this->default = $value;
+        return $this;
+    }
+
+    public function getDefault()
+    {
+        return $this->default;
+    }
+
+    public function getPrompt()
+    {
+        $prompt = $this->getDescription();
+        $default = (string) $this->getDefault();
+        if ($default !== null)
+        {
+            $prompt .= " (default: {$default})";
+        }
+        $prompt .= ": ";
+        return $prompt;
+    }
+}

--- a/src/UserInput/BasicInput.php
+++ b/src/UserInput/BasicInput.php
@@ -15,7 +15,7 @@ class BasicInput extends AbstractUserInput implements UserInputInterface
             null,
             InputOption::VALUE_REQUIRED,
             $this->getDescription(),
-            $this->getDefault(),
+            $this->getDefault()
         );
     }
 

--- a/src/UserInput/BasicInput.php
+++ b/src/UserInput/BasicInput.php
@@ -1,0 +1,29 @@
+<?php
+
+
+namespace NorthStack\NorthStackClient\UserInput;
+
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Question\Question;
+
+class BasicInput extends AbstractUserInput implements UserInputInterface
+{
+    public function asInputOption()
+    {
+        return new InputOption(
+            $this->name,
+            null,
+            InputOption::VALUE_REQUIRED,
+            $this->getDescription(),
+            $this->getDefault(),
+        );
+    }
+
+    public function asQuestion()
+    {
+        return new Question(
+            $this->getPrompt(),
+            $this->getDefault()
+        );
+    }
+}

--- a/src/UserInput/BoolInput.php
+++ b/src/UserInput/BoolInput.php
@@ -1,0 +1,33 @@
+<?php
+
+
+namespace NorthStack\NorthStackClient\UserInput;
+
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class BoolInput extends AbstractUserInput implements UserInputInterface
+{
+    private $prompt;
+    public function asInputOption()
+    {
+        return new InputOption(
+            $this->name,
+            null,
+            InputOption::VALUE_NONE,
+            $this->getDescription()
+        );
+    }
+
+    public function getPrompt()
+    {
+    }
+
+    public function asQuestion()
+    {
+        return new ConfirmationQuestion(
+            $this->getPrompt(),
+            $this->getDefault()
+        );
+    }
+}

--- a/src/UserInput/ChoiceInput.php
+++ b/src/UserInput/ChoiceInput.php
@@ -1,0 +1,36 @@
+<?php
+
+
+namespace NorthStack\NorthStackClient\UserInput;
+
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+
+class ChoiceInput extends BasicInput implements UserInputInterface
+{
+    private $choices = [];
+
+    public function setChoices($choices)
+    {
+        $this->choices = $choices;
+        return $this;
+    }
+
+    public function asQuestion()
+    {
+        return new ChoiceQuestion(
+            $this->name,
+            $this->choices,
+            $this->default
+        );
+    }
+
+    public function getDescription()
+    {
+        $desc = $this->description;
+        $desc .= " (One of: [";
+        $desc .= implode(", ", $this->choices);
+        $desc .= "])";
+        return $desc;
+    }
+}

--- a/src/UserInput/PasswordInput.php
+++ b/src/UserInput/PasswordInput.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace NorthStack\NorthStackClient\UserInput;
+
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Question\Question;
+
+class PasswordInput extends BasicInput implements UserInputInterface
+{
+    protected $length;
+
+    public function __construct($name, $description, $length = 16)
+    {
+        parent::__construct($name, $description, null);
+        $this->length = $length;
+    }
+
+    public function getDefault()
+    {
+        return "<randomly-generated>";
+    }
+
+    public function getPrompt()
+    {
+        return $this->getDescription() . " (randomly-generated if empty): ";
+    }
+
+    public function asQuestion()
+    {
+        return parent::asQuestion()->setHidden(true);
+    }
+}

--- a/src/UserInput/UserInputInterface.php
+++ b/src/UserInput/UserInputInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace NorthStack\NorthStackClient\UserInput;
+
+interface UserInputInterface
+{
+    public function asInputOption();
+    public function asQuestion();
+}


### PR DESCRIPTION
Almost usable but still WIP--any feedback welcomed.

Each app type/stack has different configuration items that need to be set. We want to allow users to define these as CLI args when they run `app:create`, falling back to prompting interactively for them.

Enter the [`UserInputInterface`](https://github.com/northstack/northstack-client/blob/14ae9de4f52de70784cccde34e788165d2db4cf8/src/UserInput/UserInputInterface.php) with several classes that implement it (`BasicInput`, `ChoiceInput`, `PasswordInput`, `BoolInput`).