### PR TITLE
Add blurb about reloading/launching a new shell after updating bashrc…

### DIFF
--- a/bin/lib-install.sh
+++ b/bin/lib-install.sh
@@ -209,12 +209,22 @@ validateOptions() {
 }
 
 dockerInstallOK() {
-    if ! checkDocker; then
+    if ! iHave docker; then
+        setError docker "No docker executable found. Is docker installed?"
         return 1
-    elif ! checkVersion docker "$MIN_DOCKER_VERSION"; then
+    fi
+
+    if ! docker info &> /dev/null; then
+        setError docker "Running \`docker info\` failed. Is the docker daemon running?"
         return 1
-    elif ! [[ $OSTYPE =~ linux || $OSTYPE =~ darwin ]]; then
-        setError OS "Docker installation is only supported on Linux & Mac"
+    fi
+
+    if ! checkVersion docker "$MIN_DOCKER_VERSION"; then
+        return 1
+    fi
+
+    if ! [[ $OSTYPE =~ linux || $OSTYPE =~ darwin ]]; then
+        setError docker "Docker installation is only supported on Linux & Mac"
         return 1
     fi
 }

--- a/bin/lib-install.sh
+++ b/bin/lib-install.sh
@@ -248,7 +248,7 @@ createRcFile() {
 
     local toCreate=()
     if iHave zsh; then
-        toCreate+=("$HOME/.zsh")
+        toCreate+=("$HOME/.zshrc")
     fi
 
     if iHave bash; then
@@ -257,10 +257,13 @@ createRcFile() {
     fi
 
     if [[ ${#toCreate[@]} -gt 0 ]]; then
-        local list; list=$(printf "- %s\n" "${toCreate[@]}")
-        if ask "Can we create the following files:\n${list}"; then
+        log warn "Couldn't find any rc files; would you like us to create them for you?"
+        local list; list=$(printf -- "- %s\n" "${toCreate[@]}")
+        if ask "The installer wants to create the following files:\n${list}"; then
             for rc in "${toCreate[@]}"; do
-                updateBashProfile "$bindir" "$rc"
+                touch "$rc"
+                updateBashProfile "$bindir" "$rc" || \
+                    log warn "Updating $rc failed"
             done
         fi
     fi
@@ -276,35 +279,38 @@ afterInstall() {
         log info "Looks like $bindir is already in your \$PATH"
     else
         log warn "$bindir is not in your \$PATH" "> $PATH"
-        if ask "Would you like us to update your .bashrc/.zshrc files?"; then
-            local files=(
-                "$HOME/.bashrc"
-                "$HOME/.bash_profile"
-                "$HOME/.zshrc"
-            )
 
-            local found=0
-            local updated=0
-            for rc in "${files[@]}"; do
+        local files=(
+            "$HOME/.bashrc"
+            "$HOME/.bash_profile"
+            "$HOME/.zshrc"
+        )
 
-                if [[ ! -f "$rc" ]]; then
-                    continue
+        local found=()
+        for rc in "${files[@]}"; do
+
+            if [[ ! -f "$rc" ]]; then
+                continue
+            fi
+
+            found+=("$rc")
+        done
+
+        if [[ ${#found[@]} -eq 0 ]]; then
+            createRcFile "$bindir"
+        else
+            if ask "Would you like us to update your .bashrc/.zshrc files?"; then
+                local updated=0
+                for rc in "${found[@]}"; do
+                    if updateBashProfile "$bindir" "$rc"; then
+                        updated=$((updated + 1))
+                        log warn "Updated rc file: '$rc'" \
+                            "You must launch a new shell or reload the rc file (\`source \"$rc\"\`) to see the changes in your \$PATH"
+                    fi
+                done
+                if (( updated == 0 )); then
+                    log warn "Failed to update rc files."
                 fi
-
-                found=$((found + 1))
-
-                if updateBashProfile "$bindir" "$rc"; then
-                    updated=$((updated + 1))
-                    log warn "Updated rc file: '$rc'" \
-                        "You must launch a new shell or reload the rc file (\`source \"$rc\"\`) to see the changes in your \$PATH"
-                fi
-            done
-
-            if (( found == 0 )); then
-                log warn "Could not find any rc files."
-                createRcFile "$bindir"
-            elif (( updated == 0 )); then
-                log warn "Failed to update rc files."
             fi
         fi
     fi

--- a/bin/lib-install.sh
+++ b/bin/lib-install.sh
@@ -304,8 +304,6 @@ afterInstall() {
                 for rc in "${found[@]}"; do
                     if updateBashProfile "$bindir" "$rc"; then
                         updated=$((updated + 1))
-                        log warn "Updated rc file: '$rc'" \
-                            "You must launch a new shell or reload the rc file (\`source \"$rc\"\`) to see the changes in your \$PATH"
                     fi
                 done
                 if (( updated == 0 )); then
@@ -382,6 +380,8 @@ updateBashProfile() {
     if ! diff "$bashFile" "$new"; then
         log info "Updating: $bashFile"
         cat "$new" > "$bashFile"
+        log warn "Updated rc file: '$bashFile'" \
+            "You must launch a new shell or reload the rc file (\`source \"$bashFile\"\`) to see the changes in your \$PATH"
     else
         debug "No changes detected--moving on"
     fi

--- a/bin/lib-install.sh
+++ b/bin/lib-install.sh
@@ -278,6 +278,18 @@ afterInstall() {
     log info "NorthStack client successfully installed at $path/bin/northstack ✅"
 }
 
+checksumFile() {
+    local -r file=$1
+    if iHave md5sum; then
+        md5sum "$file" | awk '{print $1}'
+    elif iHave md5; then
+        md5 -r "$file" | awk '{print $1}'
+    else
+        log error "Cannot checksum $file - No md5/md5sum utility found!"
+        return 1
+    fi
+}
+
 updateBashProfile() {
     local bindir=$1
     local bashFile=$2
@@ -293,7 +305,7 @@ updateBashProfile() {
         return 1
     fi
 
-    local checksumPre; checksumPre=$(md5sum "$bashFile" | awk '{print $1}')
+    local checksumPre; checksumPre=$(checksumFile "$bashFile")
     local new; new=$(mktemp)
 
     local startLine
@@ -319,7 +331,7 @@ updateBashProfile() {
         echo '# NorthStack END' >> "$new"
     fi
 
-    local checksumPost; checksumPost=$(md5sum "$bashFile" | awk '{print $1}')
+    local checksumPost; checksumPost=$(checksumFile "$bashFile")
 
     if [[ $checksumPre != "$checksumPost" ]]; then
         log error "RC file ($bashFile) changed while we were updating it"

--- a/bin/lib-install.sh
+++ b/bin/lib-install.sh
@@ -252,6 +252,8 @@ afterInstall() {
             for rc in "${files[@]}"; do
                 if updateBashProfile "$bindir" "$rc"; then
                     updated=$((updated + 1))
+                    log warn "Updated rc file: '$rc'" \
+                        "You must launch a new shell or reload the rc file (\`source \"$rc\"\`) to see the changes in your \$PATH"
                 fi
             done
             if (( updated == 0 )); then

--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -437,7 +437,7 @@ show_spinner_pid() {
     fi
     local temp
     tput civis
-    while [[ -e /proc/$pid ]]; do
+    while ps a | awk '{print $1}' | grep -q "${pid}"; do
         temp="${spinstr#?}"
         printf "[%c]  " "${spinstr}"
         spinstr=${temp}${spinstr%"${temp}"}

--- a/bin/lib.sh
+++ b/bin/lib.sh
@@ -203,6 +203,7 @@ assertSafePath() {
 
     local dir
     for dir in "${safeDirs[@]}"; do
+        dir=${dir%/}
         if [[ $path == "$dir" || $path == $dir/* ]]; then
             debug "safe dir match $path =~ $dir"
             return 0

--- a/bin/wrapper-main.sh
+++ b/bin/wrapper-main.sh
@@ -53,7 +53,7 @@ main() {
         set -- "$@" --volume /var/run/docker.sock:/var/run/docker.sock
     fi
 
-    set -- "$@" northstack "${args[@]}"
+    set -- "$@" northstack "${args[@]+${args[@]}}"
     debug "Running docker:" "$(quoteCmd "$@")"
     exec "$@"
 }

--- a/tests/bash/helpers.bash
+++ b/tests/bash/helpers.bash
@@ -2,6 +2,12 @@
 
 CLEANUP=()
 
+_debug() {
+    local -r fmt=$1
+    shift
+    printf "${fmt}\n" "$@" >&3
+}
+
 _sudo() {
     sudo --non-interactive "$@" || {
         echo "Calling sudo failed" >&3

--- a/tests/bash/test-lib-assertSafePath.bats
+++ b/tests/bash/test-lib-assertSafePath.bats
@@ -13,6 +13,13 @@ load helpers
     assertSafePath "$TMPDIR/custom-tmp/foo/bar.txt"
 }
 
+@test "Paths with trailing slashes are normalized" {
+    old=$TMPDIR
+    export TMPDIR=/foo/
+    assertSafePath "/foo/bar/"
+    export TMPDIR="$old"
+}
+
 @test "Known paths in the install prefix are safe" {
     export DEBUG=1
     export INSTALL_PREFIX=$HOME/.local

--- a/tests/bash/test-lib-install-checksumFile.bats
+++ b/tests/bash/test-lib-install-checksumFile.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+load helpers
+
+source "$BIN_DIR/lib-install.sh"
+
+@test "checksumFile runs md5sum" {
+    checksumFile "$(mktemp)"
+}


### PR DESCRIPTION
Threw in some more bugfixes in here for osx as well.

Fixes #92 #93 

Changes:

• create rc files if they don't exist (just use feature detection to decide which files to touch e.g. `command -v zsh && $create_zshrc_files`)
• manage both bashrc and bash_profile (...meh, it works at least)
• account for missing md5sum and use osx-provided `/sbin/md5` instead
• fix `$TMPDIR` path issue with trailing slash